### PR TITLE
Allow more flexible random number generation

### DIFF
--- a/src/Data/Array/Accelerate/System/Random/SFC.hs
+++ b/src/Data/Array/Accelerate/System/Random/SFC.hs
@@ -86,6 +86,11 @@ instance Shape sh => RNG (Acc (Array sh SFC64)) where
 
   random = RandomT $ state (A.unzip . A.map uniform)
 
+instance RNG (Exp SFC64) where
+  type Output (Exp SFC64) a = Exp a
+
+  random = RandomT $ state (unlift . uniform)
+
 
 data SFC a = SFC64_ a a a a
   deriving (Generic, Elt)

--- a/src/Data/Array/Accelerate/System/Random/SFC.hs
+++ b/src/Data/Array/Accelerate/System/Random/SFC.hs
@@ -198,14 +198,14 @@ instance Uniform a => Uniform (Complex a) where
 
 instance Uniform a => Uniform (Maybe a) where
   uniform s0 =
-    let T2 c s1 = uniform s0
+    let T2 c s1 = uniform @Bool s0
      in if c
            then T2 Nothing_ s1
            else first Just_ (uniform s1)
 
 instance (Uniform a, Uniform b) => Uniform (Either a b) where
   uniform s0 =
-    let T2 c s1 = uniform s0
+    let T2 c s1 = uniform @Bool s0
      in if c
            then first Left_  (uniform s1)
            else first Right_ (uniform s1)


### PR DESCRIPTION
This allows you to do random number generation for arbitrarily shaped arrays, as well as allow random number generation as part of an expression. This lets you more easily use complex data types as well as allow multiple numbers to be generated inside of a single expression. Doing RNG as part of an expression would look something like this:

```haskell
generateTuple :: Acc (Matrix SFC64) -> Acc (Matrix (Int, Float, Complex Half))
generateTuple = A.map (\gen -> evalRandom gen (T3 <$> random <*> random <*> random))

-- Or while keeping RNG state, which would probably be how you'd use this. This
-- will continuously print random numbers generated this way.
generateTuple' :: Acc (Matrix SFC64) -> Acc (Matrix ((Int, Float, Complex Half), SFC64))
generateTuple' = A.map (\gen -> A.lift $ runRandom gen (T3 <$> random <*> random <*> random))

main :: IO ()
main = go (run $ create (I2 3 3 :: Exp DIM2))
 where
  f = run1 (A.lift . A.unzip . generateTuple')
  go seeds = let (results, seeds') = f seeds in print results >> go seeds'
```

Of course, the above is just a very verbose and roundabout way to generate tuples of random values, but it does become useful when you need random number generation nested as part of an expression.

Any thoughts on this approach?

I thought it might also be interesting to have `Uniform` and `RandomT` be polymorphic in the kind of random number generator it uses instead of always using `SFC64`. Being able to swap out SFC64 for SFC32 when you care more about performance than the quality of the generated numbers sounds like a nice thing to have in a general purpose RNG library for Accelerate.
